### PR TITLE
v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 *.vsix
+.vscode
+.history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 
 ## [Unreleased]
 
+### Changed
+
+- Treat `[[[ ... ]]]` templates as embedded JavaScript language regions in YAML injections (including token type mapping for non-string tokenization).
+- Add automated tests that verify embedded language and token type manifest configuration.
+
 ## [0.1.0]
 
 ### Added
@@ -31,4 +36,3 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 ## [0.2.3] - 13th January 2023
 
 - Prepare for VSCode Marketplace
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,40 @@
 
 All notable changes to the `vscode-button-card-js` extension will be documented in this file. Using [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.0.0] - 7th March 2026
 
 ### Changed
 
 - Treat `[[[ ... ]]]` templates as embedded JavaScript language regions in YAML injections (including token type mapping for non-string tokenization).
-- Add automated tests that verify embedded language and token type manifest configuration.
-- Expand inline YAML injection selectors to cover additional Home Assistant scalar scopes.
-- Broaden bracket delimiter matching to support `[[[` and longer opening/closing sequences used by newer button-card templates.
+- Expand inline YAML injection selectors to cover additional scopes.
+- Broaden bracket delimiter matching to support `[[[` and longer opening/closing sequences used by newer button-card [nested templates](https://custom-cards.github.io/button-card/v7.0/examples/js-templates/#nested-custombutton-card).
 - Use full JavaScript grammar for block injections to improve multiline parsing behavior.
 
-## [0.1.0]
+### Fixed
 
-### Added
+- [#3](https://github.com/wfurphy/vscode-button-card-js/issues/3) Fix inconsistent syntax highlighting and insufficient tokenization of JavaScript code inside `[[[ ... ]]]` blocks. Full language support now provides proper syntax highlighting, commenting, and tokenization for JavaScript code in all contexts.
 
-- JS Triple Square Bracket Injection Grammar for `home-assistant` YAML language. To be used in combination with [Home Assistant Config Helper](https://github.com/keesschollaart81/vscode-home-assistant) extension.
+### Development
+
+- Add automated tests that verify embedded language and token type manifest configuration.
+
+--
+
+## [0.2.3] - 13th January 2023
+
+- Prepare for VSCode Marketplace
+
+## [0.2.2] - 13th January 2023
+
+- Tweak `package.json` for publishing.
+
+## [0.2.2] - 13th January 2023
+
+- Tweak `package.json` for publishing.
+
+## [0.2.1] - 13th January 2023
+
+- Prepare for VSCode Marketplace
 
 ## [0.2.0]
 
@@ -24,18 +43,21 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 
 - JS Tripple Square Brackets Injection Grammar for YAML language.
 
-## [0.2.1] - 13th January 2023
+## [0.1.0]
 
-- Prepare for VSCode Marketplace
+### Added
 
-## [0.2.2] - 13th January 2023
+- JS Triple Square Bracket Injection Grammar for `home-assistant` YAML language. To be used in combination with [Home Assistant Config Helper](https://github.com/keesschollaart81/vscode-home-assistant) extension.
 
-- Tweak `package.json` for publishing.
 
-## [0.2.2] - 13th January 2023
 
-- Tweak `package.json` for publishing.
 
-## [0.2.3] - 13th January 2023
 
-- Prepare for VSCode Marketplace
+
+
+
+
+
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 - Treat `[[[ ... ]]]` templates as embedded JavaScript language regions in YAML injections (including token type mapping for non-string tokenization).
 - Add automated tests that verify embedded language and token type manifest configuration.
 - Expand inline YAML injection selectors to cover additional Home Assistant scalar scopes.
-- Harden triple bracket matching to ignore malformed quadruple delimiters and reduce scope bleed.
+- Broaden bracket delimiter matching to support `[[[` and longer opening/closing sequences used by newer button-card templates.
 - Use full JavaScript grammar for block injections to improve multiline parsing behavior.
 
 ## [0.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 
 - Treat `[[[ ... ]]]` templates as embedded JavaScript language regions in YAML injections (including token type mapping for non-string tokenization).
 - Add automated tests that verify embedded language and token type manifest configuration.
+- Expand inline YAML injection selectors to cover additional Home Assistant scalar scopes.
+- Harden triple bracket matching to ignore malformed quadruple delimiters and reduce scope bleed.
+- Use full JavaScript grammar for block injections to improve multiline parsing behavior.
 
 ## [0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to the `vscode-button-card-js` extension will be documented 
 - Broaden bracket delimiter matching to support `[[[` and longer opening/closing sequences used by newer button-card [nested templates](https://custom-cards.github.io/button-card/v7.0/examples/js-templates/#nested-custombutton-card).
 - Use full JavaScript grammar for block injections to improve multiline parsing behavior.
 
+> :raising_hand_man: _Single line `"[[[ ... ]]]"` templates need to be terminated with a closing semicolon (`;`) or else they can break the syntax highlighting in some cases._
+
 ### Fixed
 
 - [#3](https://github.com/wfurphy/vscode-button-card-js/issues/3) Fix inconsistent syntax highlighting and insufficient tokenization of JavaScript code inside `[[[ ... ]]]` blocks. Full language support now provides proper syntax highlighting, commenting, and tokenization for JavaScript code in all contexts.

--- a/README.md
+++ b/README.md
@@ -5,21 +5,25 @@
 
 This is a very niche extension for Visual Studio Code which provides embedded Javascript language support for code blocks in YAML enclosed by triple+ square brackets (`[[[ ... ]]]`). Used when configuring the advanced _javascript templates_ properties of [Button-Card](https://github.com/custom-cards/button-card) cards for Home Assistant Lovelace dashboards.
 
-> :floppy_disk: **What's new in v1.0?** _Full language support means not just more reliable syntax highlighting but also correct commenting, tokenization, formatting, linting and more for JavaScript code inside `[[[ ... ]]]` blocks! Now your Javascript is a first class citizen inside your YAML!_
-
-* Javascript is now treated as an embedded language (not just YAML string content with Syntax Highlighting).
+* Javascript is now treated as an embedded language (not just YAML string content with syntax highlighting).
 * "Double quoted" and block YAML strings supported.
 * Support for Button-Card 7.0+ [nested templates](https://custom-cards.github.io/button-card/v7.0/examples/js-templates/#nested-custombutton-card) with longer bracket sequences like `[[[[ ... ]]]]`+.
 * Works with the standard YAML language and the `home-assistant` YAML language created by the [Home Assistant Config Helper](https://github.com/keesschollaart81/vscode-home-assistant) plugin.
 
 > :raising_hand_man: _I made this while I was working on [Creative Button Card Templates](https://github.com/wfurphy/creative-button-card-templates) and could not handle writing any more JS without syntax highlighting. Hopefully it can also provide you with relief from the same, same, string game!_
 
-## Installation
-
-### [Install from VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=wfurphy.vscode-button-card-js)
-
 ## Preview
 
 ![VSCode BC JS Example](https://raw.githubusercontent.com/wfurphy/vscode-button-card-js/master/images/vscodebcjs-example.png)
 
 _The preview above is using the OneDark Pro theme, however this plugin will work with any theme that supports yaml and javascript._
+
+## Installation
+
+### Install from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=wfurphy.vscode-button-card-js) or [Open VSX Registry](https://open-vsx.org/extension/wfurphy/vscode-button-card-js)
+
+## Usage
+
+Once installed you don't need to do anything else. Just open a YAML file that contains `[[[ ... ]]]` blocks and you should see the JavaScript syntax highlighting and language features working inside those blocks.
+
+The JavaScript in single line `"[[[ ... ]]]"` templates needs to be terminated with a closing semicolon (`;`) or else it can break the syntax highlighting in some cases.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# Button Card Javascript Syntax Highlighting in VSCode
+# Button-Card Embeded Javascript Support in YAML for VSCode
 
 ![release](https://img.shields.io/github/v/release/wfurphy/vscode-button-card-js)
 ![license](https://img.shields.io/github/license/wfurphy/vscode-button-card-js)
 
-This is a very niche extension for Visual Studio Code which provides embedded Javascript language support for code blocks in YAML enclosed by triple square brackets (`[[[ ... ]]]`). Used when configuring the advanced _javascript templates_ properties of [Button-Card](https://github.com/custom-cards/button-card) cards for Home Assistant Lovelace dashboards.
+This is a very niche extension for Visual Studio Code which provides embedded Javascript language support for code blocks in YAML enclosed by triple+ square brackets (`[[[ ... ]]]`). Used when configuring the advanced _javascript templates_ properties of [Button-Card](https://github.com/custom-cards/button-card) cards for Home Assistant Lovelace dashboards.
 
-* Javascript is treated as an embedded language (not plain YAML string content)
-* "Double quoted" and block YAML strings supported
+> :floppy_disk: **What's new in v1.0?** _Full language support means not just more reliable syntax highlighting but also correct commenting, tokenization, formatting, linting and more for JavaScript code inside `[[[ ... ]]]` blocks! Now your Javascript is a first class citizen inside your YAML!_
+
+* Javascript is now treated as an embedded language (not just YAML string content with Syntax Highlighting).
+* "Double quoted" and block YAML strings supported.
+* Support for Button-Card 7.0+ [nested templates](https://custom-cards.github.io/button-card/v7.0/examples/js-templates/#nested-custombutton-card) with longer bracket sequences like `[[[[ ... ]]]]`+.
 * Works with the standard YAML language and the `home-assistant` YAML language created by the [Home Assistant Config Helper](https://github.com/keesschollaart81/vscode-home-assistant) plugin.
 
-_I made this while I was working on [Creative Button Card Templates](https://github.com/wfurphy/creative-button-card-templates) and could not handle writing any more JS without syntax highlighting. Hopefully it gives someone else the same relief it gave me._
+> :raising_hand_man: _I made this while I was working on [Creative Button Card Templates](https://github.com/wfurphy/creative-button-card-templates) and could not handle writing any more JS without syntax highlighting. Hopefully it can also provide you with relief from the same, same, string game!_
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![release](https://img.shields.io/github/v/release/wfurphy/vscode-button-card-js)
 ![license](https://img.shields.io/github/license/wfurphy/vscode-button-card-js)
 
-This is a very niche extension for Visual Studio Code which provides syntax highlighting of Javascript code blocks in YAML which are enclosed by triple square brackets (`[[[ ... ]]]`). Used when configuring the advanced _javascript templates_ properties of [Button-Card](https://github.com/custom-cards/button-card) cards for Home Assistant Lovelace dashboards.
+This is a very niche extension for Visual Studio Code which provides embedded Javascript language support for code blocks in YAML enclosed by triple square brackets (`[[[ ... ]]]`). Used when configuring the advanced _javascript templates_ properties of [Button-Card](https://github.com/custom-cards/button-card) cards for Home Assistant Lovelace dashboards.
 
-* Syntax highlighting provided using built-in Javascript grammar
+* Javascript is treated as an embedded language (not plain YAML string content)
 * "Double quoted" and block YAML strings supported
 * Works with the standard YAML language and the `home-assistant` YAML language created by the [Home Assistant Config Helper](https://github.com/keesschollaart81/vscode-home-assistant) plugin.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Button-Card Embeded Javascript Support in YAML for VSCode
+# Button-Card Javascript Support in YAML for VSCode
 
 ![release](https://img.shields.io/github/v/release/wfurphy/vscode-button-card-js)
 ![license](https://img.shields.io/github/license/wfurphy/vscode-button-card-js)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/wfurphy/vscode-button-card-js",
   "publisher": "wfurphy",
   "license": "MIT",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "author": {
     "name": "Will Furphy",
     "url": "https://github.com/wfurphy"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
           "source.yaml"
         ],
         "embeddedLanguages": {
-          "meta.embedded.inline.js": "js"
+          "meta.embedded.inline.js": "javascript"
+        },
+        "tokenTypes": {
+          "meta.embedded.inline.js": "other"
         }
       },
       {
@@ -61,9 +64,15 @@
           "source.yaml"
         ],
         "embeddedLanguages": {
-          "meta.embedded.block.js": "js"
+          "meta.embedded.block.js": "javascript"
+        },
+        "tokenTypes": {
+          "meta.embedded.block.js": "other"
         }
       }
     ]
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/wfurphy/vscode-button-card-js",
   "publisher": "wfurphy",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "author": {
     "name": "Will Furphy",
     "url": "https://github.com/wfurphy"
@@ -15,10 +15,17 @@
   ],
   "keywords": [
     "home assistant",
+    "home-assistant",
     "button-card",
+    "button card",
     "javascript",
     "triple square brackets",
-    "syntax"
+    "square brackets",
+    "yaml",
+    "syntax highlighting",
+    "code color",
+    "code coloring",
+    "language injection"
   ],
   "extensionPack": [
     "keesschollaart.vscode-home-assistant"

--- a/syntaxes/js-block.tmLanguage.json
+++ b/syntaxes/js-block.tmLanguage.json
@@ -5,8 +5,8 @@
   "patterns": [
     {
       "name": "keyword.operator",
-      "begin": "\\[\\[\\[",
-      "end": "\\]\\]\\]",
+      "begin": "(?<!\\[)\\[\\[\\[(?!\\[)",
+      "end": "(?<!\\])\\]\\]\\](?!\\])",
       "captures": {
         "0": {
           "name": "constant.character.escape"
@@ -15,7 +15,7 @@
       "contentName": "meta.embedded.block.js",
       "patterns": [
         {
-          "include": "source.js#expression"
+          "include": "source.js"
         }
       ]
     }

--- a/syntaxes/js-block.tmLanguage.json
+++ b/syntaxes/js-block.tmLanguage.json
@@ -5,8 +5,8 @@
   "patterns": [
     {
       "name": "keyword.operator",
-      "begin": "(?<!\\[)\\[\\[\\[(?!\\[)",
-      "end": "(?<!\\])\\]\\]\\](?!\\])",
+      "begin": "\\[{3,}",
+      "end": "\\]{3,}",
       "captures": {
         "0": {
           "name": "constant.character.escape"

--- a/syntaxes/js-inline.tmLanguage.json
+++ b/syntaxes/js-inline.tmLanguage.json
@@ -1,12 +1,12 @@
 {
   "scopeName": "js-inline.injection",
-  "injectionSelector": "L:string.quoted.double",
+  "injectionSelector": "L:string.quoted.double, L:string.quoted.single, L:string.unquoted.plain.out, L:string.unquoted.plain.in",
   "name": "Grammar for Button-Card Javascript expressions surrounded by triple square brackets in quoted strings",
   "patterns": [
     {
       "name": "keyword.operator",
-      "begin": "\\[\\[\\[",
-      "end": "\\]\\]\\]",
+      "begin": "(?<!\\[)\\[\\[\\[(?!\\[)",
+      "end": "(?<!\\])\\]\\]\\](?!\\])",
       "captures": {
         "0": {
           "name": "constant.character.escape"

--- a/syntaxes/js-inline.tmLanguage.json
+++ b/syntaxes/js-inline.tmLanguage.json
@@ -5,8 +5,8 @@
   "patterns": [
     {
       "name": "keyword.operator",
-      "begin": "(?<!\\[)\\[\\[\\[(?!\\[)",
-      "end": "(?<!\\])\\]\\]\\](?!\\])",
+      "begin": "\\[{3,}",
+      "end": "\\]{3,}",
       "captures": {
         "0": {
           "name": "constant.character.escape"

--- a/test/embedded-language-config.test.mjs
+++ b/test/embedded-language-config.test.mjs
@@ -11,6 +11,15 @@ function loadManifest() {
 }
 
 /**
+ * Loads a TextMate grammar JSON file from the extension syntaxes directory.
+ * @param {string} fileName Grammar file name.
+ * @returns {Record<string, unknown>} Parsed grammar JSON.
+ */
+function loadGrammar(fileName) {
+  return JSON.parse(readFileSync(new URL(`../syntaxes/${fileName}`, import.meta.url), 'utf8'));
+}
+
+/**
  * Finds grammar contributions by scope name.
  * @param {Record<string, unknown>} manifest Parsed extension manifest.
  * @returns {{inline: Record<string, unknown>, block: Record<string, unknown>}} Inline and block grammar entries.
@@ -40,4 +49,31 @@ test('embedded javascript scopes are tokenized as non-string content', () => {
 
   assert.equal(inline.tokenTypes?.['meta.embedded.inline.js'], 'other');
   assert.equal(block.tokenTypes?.['meta.embedded.block.js'], 'other');
+});
+
+test('inline grammar supports quoted and plain scalar YAML scopes', () => {
+  const inlineGrammar = loadGrammar('js-inline.tmLanguage.json');
+  const selector = inlineGrammar.injectionSelector;
+
+  assert.equal(
+    selector,
+    'L:string.quoted.double, L:string.quoted.single, L:string.unquoted.plain.out, L:string.unquoted.plain.in'
+  );
+});
+
+test('grammars only match exact triple bracket delimiters', () => {
+  const inlinePattern = loadGrammar('js-inline.tmLanguage.json').patterns?.[0];
+  const blockPattern = loadGrammar('js-block.tmLanguage.json').patterns?.[0];
+
+  assert.equal(inlinePattern?.begin, '(?<!\\[)\\[\\[\\[(?!\\[)');
+  assert.equal(inlinePattern?.end, '(?<!\\])\\]\\]\\](?!\\])');
+  assert.equal(blockPattern?.begin, '(?<!\\[)\\[\\[\\[(?!\\[)');
+  assert.equal(blockPattern?.end, '(?<!\\])\\]\\]\\](?!\\])');
+});
+
+test('block grammar uses full JavaScript grammar for multiline template support', () => {
+  const blockPattern = loadGrammar('js-block.tmLanguage.json').patterns?.[0];
+  const included = blockPattern?.patterns?.[0]?.include;
+
+  assert.equal(included, 'source.js');
 });

--- a/test/embedded-language-config.test.mjs
+++ b/test/embedded-language-config.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Loads the extension manifest for configuration assertions.
+ * @returns {Record<string, unknown>} Parsed package.json object.
+ */
+function loadManifest() {
+  return JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+}
+
+/**
+ * Finds grammar contributions by scope name.
+ * @param {Record<string, unknown>} manifest Parsed extension manifest.
+ * @returns {{inline: Record<string, unknown>, block: Record<string, unknown>}} Inline and block grammar entries.
+ */
+function getButtonCardGrammars(manifest) {
+  const grammars = manifest.contributes?.grammars;
+  assert.ok(Array.isArray(grammars), 'Expected contributes.grammars to be an array');
+
+  const inline = grammars.find((grammar) => grammar.scopeName === 'js-inline.injection');
+  const block = grammars.find((grammar) => grammar.scopeName === 'js-block.injection');
+
+  assert.ok(inline, 'Missing js-inline.injection grammar contribution');
+  assert.ok(block, 'Missing js-block.injection grammar contribution');
+
+  return { inline, block };
+}
+
+test('inline and block injections declare embedded javascript language', () => {
+  const { inline, block } = getButtonCardGrammars(loadManifest());
+
+  assert.equal(inline.embeddedLanguages?.['meta.embedded.inline.js'], 'javascript');
+  assert.equal(block.embeddedLanguages?.['meta.embedded.block.js'], 'javascript');
+});
+
+test('embedded javascript scopes are tokenized as non-string content', () => {
+  const { inline, block } = getButtonCardGrammars(loadManifest());
+
+  assert.equal(inline.tokenTypes?.['meta.embedded.inline.js'], 'other');
+  assert.equal(block.tokenTypes?.['meta.embedded.block.js'], 'other');
+});

--- a/test/embedded-language-config.test.mjs
+++ b/test/embedded-language-config.test.mjs
@@ -61,14 +61,14 @@ test('inline grammar supports quoted and plain scalar YAML scopes', () => {
   );
 });
 
-test('grammars only match exact triple bracket delimiters', () => {
+test('grammars match three or more bracket delimiters', () => {
   const inlinePattern = loadGrammar('js-inline.tmLanguage.json').patterns?.[0];
   const blockPattern = loadGrammar('js-block.tmLanguage.json').patterns?.[0];
 
-  assert.equal(inlinePattern?.begin, '(?<!\\[)\\[\\[\\[(?!\\[)');
-  assert.equal(inlinePattern?.end, '(?<!\\])\\]\\]\\](?!\\])');
-  assert.equal(blockPattern?.begin, '(?<!\\[)\\[\\[\\[(?!\\[)');
-  assert.equal(blockPattern?.end, '(?<!\\])\\]\\]\\](?!\\])');
+  assert.equal(inlinePattern?.begin, '\\[{3,}');
+  assert.equal(inlinePattern?.end, '\\]{3,}');
+  assert.equal(blockPattern?.begin, '\\[{3,}');
+  assert.equal(blockPattern?.end, '\\]{3,}');
 });
 
 test('block grammar uses full JavaScript grammar for multiline template support', () => {


### PR DESCRIPTION
## [1.0.0] - 7th March 2026

### Changed

- Treat `[[[ ... ]]]` templates as embedded JavaScript language regions in YAML injections (including token type mapping for non-string tokenisation).
- Expand inline YAML injection selectors to cover additional scopes.
- Broaden bracket delimiter matching to support `[[[` and longer opening/closing sequences used by newer button-card [nested templates](https://custom-cards.github.io/button-card/v7.0/examples/js-templates/#nested-custombutton-card).
- Use full JavaScript grammar for block injections to improve multiline parsing behaviour.

> :raising_hand_man: _Single line `"[[[ ... ]]]"` templates need to be terminated with a closing semicolon (`;`) or else they can break the syntax highlighting in some cases._

### Fixed

- [#3](https://github.com/wfurphy/vscode-button-card-js/issues/3) Fix inconsistent syntax highlighting and insufficient tokenisation of JavaScript code inside `[[[ ... ]]]` blocks. Full language support now provides proper syntax highlighting, commenting, and tokenisation for JavaScript code in all contexts.

### Development

- Add automated tests that verify embedded language and token type manifest configuration.